### PR TITLE
Change to All.php

### DIFF
--- a/lib/ApiOperations/All.php
+++ b/lib/ApiOperations/All.php
@@ -19,20 +19,6 @@ trait All
     {
         self::_validateParams($params);
 
-        // Convert filter[] pararms
-        if (is_array($params)) {
-            foreach ($params as $name => $val) {
-
-                // Make sure this isn't a page[] param
-                if (strpos($name, '[') === false && strpos($name, ']') === false) {
-
-                    // Enclose param in filter[] and remove old param
-                    $params['filter[' . $name . ']'] = $val;
-                    unset($params[$name]);
-                }
-            }
-        }
-
         $url = static::classUrl();
 
         list($response, $opts) = static::_staticRequest('get', $url, $params, $opts);


### PR DESCRIPTION
Fixed a bug which wraps parameters with filter[] when using trait ::all(['param'=>123]); For example,

endpoint?filter[param]=123
should be just
endpoint?param=123

This update corrects this bug.