### PR TITLE
Collections Bug Fixes

### DIFF
--- a/lib/ApiRequestor.php
+++ b/lib/ApiRequestor.php
@@ -413,9 +413,13 @@ class ApiRequestor
     {
         $resp = json_decode($rbody, true);
 
-        // Move [data] to the parent node
+
         if (isset($resp['data'])) {
-            $resp = $resp['data'];
+            // If this is not a collection, then 'record_type' should be present
+            if (isset($resp['data']['record_type']) || !isset($resp['meta'])) {
+                // then move [data] to the parent node
+                $resp = $resp['data'];
+            }
         }
 
         $jsonError = json_last_error();

--- a/lib/Collection.php
+++ b/lib/Collection.php
@@ -87,6 +87,79 @@ class Collection extends TelnyxObject implements \IteratorAggregate
         return new Util\AutoPagingIterator($this, $this->_requestParams);
     }
 
+    /**
+     * Returns an empty collection. This is returned from {@see nextPage()}
+     * when we know that there isn't a next page in order to replicate the
+     * behavior of the API when it attempts to return a page beyond the last.
+     *
+     * @param array|string|null $opts
+     * @return Collection
+     */
+    public static function emptyCollection($opts = null)
+    {
+        return Collection::constructFrom(['data' => []], $opts);
+    }
+
+    /**
+     * Returns true if the page object contains no element.
+     *
+     * @return boolean
+     */
+    public function isEmpty()
+    {
+        return empty($this->data);
+    }
+
+    /**
+     * Fetches the next page in the resource list (if there is one).
+     *
+     * This method will try to respect the limit of the current page. If none
+     * was given, the default limit will be fetched again.
+     *
+     * @param array|null $params
+     * @param array|string|null $opts
+     * @return Collection
+     */
+    public function nextPage($params = null, $opts = null)
+    {
+        if (!$this->has_more) {
+            return static::emptyCollection($opts);
+        }
+
+        $lastId = end($this->data)->id;
+
+        $params = array_merge(
+            $this->_requestParams,
+            ['starting_after' => $lastId],
+            $params ?: []
+        );
+
+        return $this->all($params, $opts);
+    }
+
+    /**
+     * Fetches the previous page in the resource list (if there is one).
+     *
+     * This method will try to respect the limit of the current page. If none
+     * was given, the default limit will be fetched again.
+     *
+     * @param array|null $params
+     * @param array|string|null $opts
+     * @return Collection
+     */
+    public function previousPage($params = null, $opts = null)
+    {
+        $firstId = $this->data[0]->id;
+
+        $params = array_merge(
+            $this->_requestParams,
+            ['ending_before' => $firstId],
+            $params ?: []
+        );
+
+        return $this->all($params, $opts);
+    }
+
     private function extractPathAndUpdateParams($params)
     {
         $url = parse_url($this->url);

--- a/tests/api_resources/AddressTest.php
+++ b/tests/api_resources/AddressTest.php
@@ -6,7 +6,6 @@ class AddressTest extends TestCase
 {
     const TEST_RESOURCE_ID = '123';
 
-
     public function testIsListable()
     {
         $this->expectsRequest(
@@ -15,7 +14,7 @@ class AddressTest extends TestCase
         );
         $resources = Address::all();
         $this->assertInstanceOf(\Telnyx\Collection::class, $resources);
-        $this->assertInstanceOf(\Telnyx\Address::class, $resources[0]);
+        $this->assertInstanceOf(\Telnyx\Address::class, $resources['data'][0]);
     }
 
     public function testIsCreatable()
@@ -48,5 +47,4 @@ class AddressTest extends TestCase
         $resource = Address::retrieve(self::TEST_RESOURCE_ID);
         $this->assertInstanceOf(\Telnyx\Address::class, $resource);
     }
-
 }

--- a/tests/api_resources/AvailablePhoneNumberTest.php
+++ b/tests/api_resources/AvailablePhoneNumberTest.php
@@ -18,6 +18,6 @@ class TestAvailablePhoneNumber extends TestCase
             ]
         ]);
         $this->assertInstanceOf(\Telnyx\Collection::class, $resources);
-        $this->assertInstanceOf(\Telnyx\AvailablePhoneNumber::class, $resources[0]);
+        $this->assertInstanceOf(\Telnyx\AvailablePhoneNumber::class, $resources['data'][0]);
     }
 }

--- a/tests/api_resources/BillingGroupTest.php
+++ b/tests/api_resources/BillingGroupTest.php
@@ -6,7 +6,6 @@ class BillingGroupTest extends TestCase
 {
     const TEST_RESOURCE_ID = '123';
 
-
     public function testIsListable()
     {
         $this->expectsRequest(
@@ -15,7 +14,7 @@ class BillingGroupTest extends TestCase
         );
         $resources = BillingGroup::all();
         $this->assertInstanceOf(\Telnyx\Collection::class, $resources);
-        $this->assertInstanceOf(\Telnyx\BillingGroup::class, $resources[0]);
+        $this->assertInstanceOf(\Telnyx\BillingGroup::class, $resources['data'][0]);
     }
 
     public function testIsCreatable()

--- a/tests/api_resources/ConnectionTest.php
+++ b/tests/api_resources/ConnectionTest.php
@@ -14,7 +14,7 @@ class ConnectionTest extends TestCase
         );
         $resources = Connection::all();
         $this->assertInstanceOf(\Telnyx\Collection::class, $resources);
-        $this->assertInstanceOf(\Telnyx\IPConnection::class, $resources[0]);
+        $this->assertInstanceOf(\Telnyx\IPConnection::class, $resources['data'][0]);
     }
 
     public function testIsRetrievable()
@@ -26,5 +26,4 @@ class ConnectionTest extends TestCase
         $resource = Connection::retrieve(self::TEST_RESOURCE_ID);
         $this->assertInstanceOf(\Telnyx\Connection::class, $resource);
     }
-
 }

--- a/tests/api_resources/CredentialConnectionTest.php
+++ b/tests/api_resources/CredentialConnectionTest.php
@@ -14,7 +14,7 @@ class CredentialConnectionTest extends TestCase
         );
         $resources = CredentialConnection::all();
         $this->assertInstanceOf(\Telnyx\Collection::class, $resources);
-        $this->assertInstanceOf(\Telnyx\CredentialConnection::class, $resources[0]);
+        $this->assertInstanceOf(\Telnyx\CredentialConnection::class, $resources['data'][0]);
     }
 
     public function testIsCreatable()
@@ -59,5 +59,4 @@ class CredentialConnectionTest extends TestCase
         ]);
         $this->assertInstanceOf(\Telnyx\CredentialConnection::class, $resource);
     }
-    
 }

--- a/tests/api_resources/FQDNConnectionTest.php
+++ b/tests/api_resources/FQDNConnectionTest.php
@@ -14,7 +14,7 @@ class FQDNConnectionTest extends TestCase
         );
         $resources = FQDNConnection::all();
         $this->assertInstanceOf(\Telnyx\Collection::class, $resources);
-        $this->assertInstanceOf(\Telnyx\FQDNConnection::class, $resources[0]);
+        $this->assertInstanceOf(\Telnyx\FQDNConnection::class, $resources['data'][0]);
     }
 
     public function testIsCreatable()
@@ -59,5 +59,4 @@ class FQDNConnectionTest extends TestCase
         ]);
         $this->assertInstanceOf(\Telnyx\FQDNConnection::class, $resource);
     }
-    
 }

--- a/tests/api_resources/FQDNTest.php
+++ b/tests/api_resources/FQDNTest.php
@@ -14,7 +14,7 @@ class FQDNTest extends TestCase
         );
         $resources = FQDN::all();
         $this->assertInstanceOf(\Telnyx\Collection::class, $resources);
-        $this->assertInstanceOf(\Telnyx\FQDN::class, $resources[0]);
+        $this->assertInstanceOf(\Telnyx\FQDN::class, $resources['data'][0]);
     }
 
     public function testIsCreatable()
@@ -59,5 +59,4 @@ class FQDNTest extends TestCase
         ]);
         $this->assertInstanceOf(\Telnyx\FQDN::class, $resource);
     }
-    
 }

--- a/tests/api_resources/IPConnectionTest.php
+++ b/tests/api_resources/IPConnectionTest.php
@@ -14,7 +14,7 @@ class IPConnectionTest extends TestCase
         );
         $resources = IPConnection::all();
         $this->assertInstanceOf(\Telnyx\Collection::class, $resources);
-        $this->assertInstanceOf(\Telnyx\IPConnection::class, $resources[0]);
+        $this->assertInstanceOf(\Telnyx\IPConnection::class, $resources['data'][0]);
     }
 
     public function testIsCreatable()
@@ -59,5 +59,4 @@ class IPConnectionTest extends TestCase
         ]);
         $this->assertInstanceOf(\Telnyx\IPConnection::class, $resource);
     }
-
 }

--- a/tests/api_resources/IPTest.php
+++ b/tests/api_resources/IPTest.php
@@ -14,7 +14,7 @@ class IPTest extends TestCase
         );
         $resources = IP::all();
         $this->assertInstanceOf(\Telnyx\Collection::class, $resources);
-        $this->assertInstanceOf(\Telnyx\IP::class, $resources[0]);
+        $this->assertInstanceOf(\Telnyx\IP::class, $resources['data'][0]);
     }
 
     public function testIsCreatable()
@@ -60,5 +60,4 @@ class IPTest extends TestCase
         ]);
         $this->assertInstanceOf(\Telnyx\IP::class, $resource);
     }
-    
 }

--- a/tests/api_resources/InboundChannelsTest.php
+++ b/tests/api_resources/InboundChannelsTest.php
@@ -26,5 +26,4 @@ class InboundChannelTest extends TestCase
         ]);
         $this->assertInstanceOf(\Telnyx\InboundChannel::class, $resource);
     }
-
 }

--- a/tests/api_resources/MessageTest.php
+++ b/tests/api_resources/MessageTest.php
@@ -4,12 +4,6 @@ namespace Telnyx;
 
 class MessageTest extends TestCase
 {
-    const TEST_MESSAGING_PROFILE_ID = "d120432d-2e77-4583-87f8-1db837cee559";
-    const TEST_SRC_LONG_CODE = "+13125550100";
-    const TEST_SRC_ALPHANUMERIC = "Testing 123";
-    const TEST_DST = "+17735550100";
-    const TEST_MESSAGE_BODY = "Hello!";
-
     public function testCanCreateStandardMessage()
     {
         $this->expectsRequest(
@@ -18,9 +12,9 @@ class MessageTest extends TestCase
         );
 
         $resource = \Telnyx\Message::Create([
-            "from" => static::TEST_SRC_LONG_CODE,
-            "to" => static::TEST_DST,
-            "text" => static::TEST_MESSAGE_BODY
+            "from" => "+13125550100",
+            "to" => "+17735550100",
+            "text" => "Hello!"
         ]);
 
         $this->assertInstanceOf(\Telnyx\Message::class, $resource);

--- a/tests/api_resources/MessagingPhoneNumberTest.php
+++ b/tests/api_resources/MessagingPhoneNumberTest.php
@@ -14,7 +14,7 @@ class MessagingPhoneNumberTest extends TestCase
         );
         $resources = MessagingPhoneNumber::all();
         $this->assertInstanceOf(\Telnyx\Collection::class, $resources);
-        $this->assertInstanceOf(\Telnyx\MessagingPhoneNumber::class, $resources[0]);
+        $this->assertInstanceOf(\Telnyx\MessagingPhoneNumber::class, $resources['data'][0]);
     }
 
     public function testIsRetrievable()

--- a/tests/api_resources/MessagingProfileTest.php
+++ b/tests/api_resources/MessagingProfileTest.php
@@ -15,7 +15,7 @@ class MessagingProfileTest extends TestCase
         );
         $resources = MessagingProfile::all();
         $this->assertInstanceOf(\Telnyx\Collection::class, $resources);
-        $this->assertInstanceOf(\Telnyx\MessagingProfile::class, $resources[0]);
+        $this->assertInstanceOf(\Telnyx\MessagingProfile::class, $resources['data'][0]);
     }
 
     public function testIsRetrievable()
@@ -71,7 +71,7 @@ class MessagingProfileTest extends TestCase
         );
         $resources = $messaging_profile->phone_numbers();
         $this->assertInstanceOf(\Telnyx\MessagingProfile::class, $resources);
-        $this->assertInstanceOf(\Telnyx\MessagingPhoneNumber::class, $resources[0]);
+        $this->assertInstanceOf(\Telnyx\MessagingPhoneNumber::class, $resources['data'][0]);
     }
 
     public function testCanCallShortCodes()
@@ -83,7 +83,6 @@ class MessagingProfileTest extends TestCase
         );
         $resources = $messaging_profile->short_codes();
         $this->assertInstanceOf(\Telnyx\MessagingProfile::class, $resources);
-        $this->assertInstanceOf(\Telnyx\ShortCode::class, $resources[0]);
+        $this->assertInstanceOf(\Telnyx\ShortCode::class, $resources['data'][0]);
     }
-
 }

--- a/tests/api_resources/NumberOrderDocumentTest.php
+++ b/tests/api_resources/NumberOrderDocumentTest.php
@@ -6,7 +6,6 @@ class NumberOrderDocumentTest extends TestCase
 {
     const TEST_RESOURCE_ID = '123';
 
-
     public function testIsListable()
     {
         $this->expectsRequest(
@@ -15,7 +14,7 @@ class NumberOrderDocumentTest extends TestCase
         );
         $resources = NumberOrderDocument::all();
         $this->assertInstanceOf(\Telnyx\Collection::class, $resources);
-        $this->assertInstanceOf(\Telnyx\NumberOrderDocument::class, $resources[0]);
+        $this->assertInstanceOf(\Telnyx\NumberOrderDocument::class, $resources['data'][0]);
     }
 
     public function testIsCreatable()

--- a/tests/api_resources/NumberOrderTest.php
+++ b/tests/api_resources/NumberOrderTest.php
@@ -14,7 +14,7 @@ class NumberOrderTest extends TestCase
         );
         $resources = NumberOrder::all();
         $this->assertInstanceOf(\Telnyx\Collection::class, $resources);
-        $this->assertInstanceOf(\Telnyx\NumberOrder::class, $resources[0]);
+        $this->assertInstanceOf(\Telnyx\NumberOrder::class, $resources['data'][0]);
     }
 
     public function testIsRetrievable()

--- a/tests/api_resources/NumberReservationTest.php
+++ b/tests/api_resources/NumberReservationTest.php
@@ -14,7 +14,7 @@ class NumberReservationTest extends TestCase
         );
         $resources = NumberReservation::all();
         $this->assertInstanceOf(\Telnyx\Collection::class, $resources);
-        $this->assertInstanceOf(\Telnyx\NumberReservation::class, $resources[0]);
+        $this->assertInstanceOf(\Telnyx\NumberReservation::class, $resources['data'][0]);
     }
 
     public function testIsRetrievable()

--- a/tests/api_resources/OutboundVoiceProfileTest.php
+++ b/tests/api_resources/OutboundVoiceProfileTest.php
@@ -14,7 +14,7 @@ class OutboundVoiceProfileTest extends TestCase
         );
         $resources = OutboundVoiceProfile::all();
         $this->assertInstanceOf(\Telnyx\Collection::class, $resources);
-        $this->assertInstanceOf(\Telnyx\OutboundVoiceProfile::class, $resources[0]);
+        $this->assertInstanceOf(\Telnyx\OutboundVoiceProfile::class, $resources['data'][0]);
     }
 
     public function testIsCreatable()
@@ -59,5 +59,4 @@ class OutboundVoiceProfileTest extends TestCase
         ]);
         $this->assertInstanceOf(\Telnyx\OutboundVoiceProfile::class, $resource);
     }
-    
 }

--- a/tests/api_resources/PhoneNumber/MessagingTest.php
+++ b/tests/api_resources/PhoneNumber/MessagingTest.php
@@ -13,7 +13,7 @@ class MessagingTest extends \Telnyx\TestCase
         );
         $resources = Messaging::all();
         $this->assertInstanceOf(\Telnyx\Collection::class, $resources);
-        $this->assertInstanceOf(\Telnyx\PhoneNumber\Messaging::class, $resources[0]);
+        $this->assertInstanceOf(\Telnyx\PhoneNumber\Messaging::class, $resources['data'][0]);
     }
 
 }

--- a/tests/api_resources/PhoneNumber/VoiceTest.php
+++ b/tests/api_resources/PhoneNumber/VoiceTest.php
@@ -13,7 +13,7 @@ class VoiceTest extends \Telnyx\TestCase
         );
         $resources = Voice::all();
         $this->assertInstanceOf(\Telnyx\Collection::class, $resources);
-        $this->assertInstanceOf(\Telnyx\PhoneNumber\Voice::class, $resources[0]);
+        $this->assertInstanceOf(\Telnyx\PhoneNumber\Voice::class, $resources['data'][0]);
     }
 
 }

--- a/tests/api_resources/PhoneNumberTest.php
+++ b/tests/api_resources/PhoneNumberTest.php
@@ -6,7 +6,6 @@ class PhoneNumberTest extends TestCase
 {
     const TEST_RESOURCE_ID = '123';
 
-
     public function testIsListable()
     {
         $this->expectsRequest(
@@ -15,7 +14,7 @@ class PhoneNumberTest extends TestCase
         );
         $resources = PhoneNumber::all();
         $this->assertInstanceOf(\Telnyx\Collection::class, $resources);
-        $this->assertInstanceOf(\Telnyx\PhoneNumber::class, $resources[0]);
+        $this->assertInstanceOf(\Telnyx\PhoneNumber::class, $resources['data'][0]);
     }
 
     public function testIsUpdatable()
@@ -30,21 +29,18 @@ class PhoneNumberTest extends TestCase
         $this->assertInstanceOf(\Telnyx\PhoneNumber::class, $resource);
     }
 
-    /*
     public function testIsRetrievable()
     {
-        // NOTE: retrieve not available in stripe-mock test
         $this->expectsRequest(
             'get',
-            '/v2/billing_groups/' . urlencode(self::TEST_RESOURCE_ID)
+            '/v2/phone_numbers/' . urlencode(self::TEST_RESOURCE_ID)
         );
-        $resource = BillingGroup::retrieve(self::TEST_RESOURCE_ID);
-        $this->assertInstanceOf(\Telnyx\BillingGroup::class, $resource);
+        $resource = PhoneNumber::retrieve(self::TEST_RESOURCE_ID);
+        $this->assertInstanceOf(\Telnyx\PhoneNumber::class, $resource);
     }
 
     public function testIsDeletable()
     {
-        // NOTE: retrieve not available in stripe-mock test
         $resource = PhoneNumber::retrieve(self::TEST_RESOURCE_ID);
         $this->expectsRequest(
             'delete',
@@ -53,6 +49,4 @@ class PhoneNumberTest extends TestCase
         $resource->delete();
         $this->assertInstanceOf(\Telnyx\PhoneNumber::class, $resource);
     }
-    */
-
 }

--- a/tests/api_resources/PortoutTest.php
+++ b/tests/api_resources/PortoutTest.php
@@ -6,7 +6,6 @@ class PortoutTest extends TestCase
 {
     const TEST_RESOURCE_ID = '123';
 
-
     public function testIsListable()
     {
         $this->expectsRequest(
@@ -15,7 +14,7 @@ class PortoutTest extends TestCase
         );
         $resources = Portout::all();
         $this->assertInstanceOf(\Telnyx\Collection::class, $resources);
-        $this->assertInstanceOf(\Telnyx\Portout::class, $resources[0]);
+        $this->assertInstanceOf(\Telnyx\Portout::class, $resources['data'][0]);
     }
 
     public function testIsRetrievable()
@@ -49,7 +48,7 @@ class PortoutTest extends TestCase
         );
         $resources = $portout->list_comments();
         $this->assertInstanceOf(\Telnyx\Collection::class, $resources);
-        $this->assertInstanceOf(\Telnyx\Portout::class, $resources[0]);
+        $this->assertInstanceOf(\Telnyx\Portout::class, $resources['data'][0]);
     }
 
     public function testCreateComments()
@@ -62,5 +61,4 @@ class PortoutTest extends TestCase
         $resources = $portout->list_comments();
         $this->assertInstanceOf(\Telnyx\Portout::class, $resources);
     }
-
 }

--- a/tests/api_resources/RegulatoryRequirementTest.php
+++ b/tests/api_resources/RegulatoryRequirementTest.php
@@ -6,7 +6,6 @@ class RegulatoryRequirementTest extends TestCase
 {
     const TEST_RESOURCE_ID = '123';
 
-
     public function testIsListable()
     {
         $this->expectsRequest(
@@ -15,7 +14,7 @@ class RegulatoryRequirementTest extends TestCase
         );
         $resources = RegulatoryRequirement::all();
         $this->assertInstanceOf(\Telnyx\Collection::class, $resources);
-        $this->assertInstanceOf(\Telnyx\RegulatoryRequirement::class, $resources[0]);
+        $this->assertInstanceOf(\Telnyx\RegulatoryRequirement::class, $resources['data'][0]);
     }
 
     public function testIsRetrievable()

--- a/tests/api_resources/ShortCodeTest.php
+++ b/tests/api_resources/ShortCodeTest.php
@@ -14,7 +14,7 @@ class ShortCodeTest extends TestCase
         );
         $resources = ShortCode::all();
         $this->assertInstanceOf(\Telnyx\Collection::class, $resources);
-        $this->assertInstanceOf(\Telnyx\ShortCode::class, $resources[0]);
+        $this->assertInstanceOf(\Telnyx\ShortCode::class, $resources['data'][0]);
     }
 
     public function testIsRetrievable()

--- a/tests/api_resources/SimCardTest.php
+++ b/tests/api_resources/SimCardTest.php
@@ -4,7 +4,6 @@ namespace Telnyx;
 
 class SimCardTest extends TestCase
 {
-    
     const TEST_RESOURCE_ID = '6a09cdc3-8948-47f0-aa62-74ac943d6c58';
 
     public function testIsListable()
@@ -15,7 +14,7 @@ class SimCardTest extends TestCase
         );
         $resources = SimCard::all();
         $this->assertInstanceOf(\Telnyx\Collection::class, $resources);
-        $this->assertInstanceOf(\Telnyx\SimCard::class, $resources[0]);
+        $this->assertInstanceOf(\Telnyx\SimCard::class, $resources['data'][0]);
     }
 
     public function testIsRetrievable()
@@ -71,5 +70,4 @@ class SimCardTest extends TestCase
         $resources = SimCard::register(["registration_codes" => ["1234567890, 123456332601"]]);
         $this->assertInstanceOf(\Telnyx\SimCard::class, $resources);
     }
-
 }


### PR DESCRIPTION
* Collections - 'meta' and 'data' is now separated
* Collections - Added isEmpty()
* Updated tests for Collections
* Updated other tests to expect $resources['data'][0] instead of $resources[0]
* Uncommented previously broken tests in PhoneNumberTest.php
* Minor updates to formatting in tests