### PR TITLE
Fix PHP 8.1 deprecations in `TelnyxObject` class.

### DIFF
--- a/lib/Collection.php
+++ b/lib/Collection.php
@@ -77,7 +77,7 @@ class Collection extends TelnyxObject implements \IteratorAggregate
      * @return \ArrayIterator An iterator that can be used to iterate
      *    across objects in the current page.
      */
-    public function getIterator()
+    public function getIterator(): \ArrayIterator
     {
         return new \ArrayIterator($this->data);
     }

--- a/lib/TelnyxObject.php
+++ b/lib/TelnyxObject.php
@@ -178,28 +178,28 @@ class TelnyxObject implements \ArrayAccess, \Countable, \JsonSerializable
     }
 
     // ArrayAccess methods
-    public function offsetSet($k, $v)
+    public function offsetSet(mixed $k, mixed $v): void
     {
         $this->$k = $v;
     }
 
-    public function offsetExists($k)
+    public function offsetExists(mixed $k): bool
     {
         return array_key_exists($k, $this->_values);
     }
 
-    public function offsetUnset($k)
+    public function offsetUnset(mixed $k): void
     {
         unset($this->$k);
     }
 
-    public function offsetGet($k)
+    public function offsetGet(mixed $k): mixed
     {
         return array_key_exists($k, $this->_values) ? $this->_values[$k] : null;
     }
 
     // Countable method
-    public function count()
+    public function count(): int
     {
         return count($this->_values);
     }
@@ -406,7 +406,7 @@ class TelnyxObject implements \ArrayAccess, \Countable, \JsonSerializable
         }
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray(true);
     }
@@ -417,7 +417,7 @@ class TelnyxObject implements \ArrayAccess, \Countable, \JsonSerializable
      *
      * @return array the associative array
      */
-    public function toArray()
+    public function toArray(): array
     {
         $maybeToArray = function ($value) {
             if (null === $value) {

--- a/lib/Util/AutoPagingIterator.php
+++ b/lib/Util/AutoPagingIterator.php
@@ -15,7 +15,7 @@ class AutoPagingIterator implements \Iterator
         $this->params = $params;
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         // Actually rewinding would require making a copy of the original page.
     }
@@ -33,6 +33,10 @@ class AutoPagingIterator implements \Iterator
         return key($this->page->data) + $this->pageOffset;
     }
 
+    /**
+     * @return void|false This will only return void in the future due to https://wiki.php.net/rfc/internal_method_return_types.
+     */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         $item = next($this->page->data);
@@ -52,7 +56,7 @@ class AutoPagingIterator implements \Iterator
         }
     }
 
-    public function valid()
+    public function valid(): bool
     {
         $key = key($this->page->data);
         $valid = ($key !== null && $key !== false);

--- a/lib/Util/CaseInsensitiveArray.php
+++ b/lib/Util/CaseInsensitiveArray.php
@@ -23,17 +23,17 @@ class CaseInsensitiveArray implements \ArrayAccess, \Countable, \IteratorAggrega
         $this->container = \array_change_key_case($initial_array, \CASE_LOWER);
     }
 
-    public function count()
+    public function count(): int
     {
         return \count($this->container);
     }
 
-    public function getIterator()
+    public function getIterator(): \ArrayIterator
     {
         return new \ArrayIterator($this->container);
     }
 
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         $offset = static::maybeLowercase($offset);
         if (null === $offset) {
@@ -43,20 +43,20 @@ class CaseInsensitiveArray implements \ArrayAccess, \Countable, \IteratorAggrega
         }
     }
 
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         $offset = static::maybeLowercase($offset);
 
         return isset($this->container[$offset]);
     }
 
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         $offset = static::maybeLowercase($offset);
         unset($this->container[$offset]);
     }
 
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         $offset = static::maybeLowercase($offset);
 

--- a/lib/Util/Set.php
+++ b/lib/Util/Set.php
@@ -37,7 +37,7 @@ class Set implements IteratorAggregate
         return \array_keys($this->_elts);
     }
 
-    public function getIterator()
+    public function getIterator(): \ArrayIterator
     {
         return new ArrayIterator($this->toArray());
     }


### PR DESCRIPTION
This PR fixes various deprecation warnings that are thrown when using PHP 8.1, e.g.:

Return type of `Telnyx\TelnyxObject::offsetExists($k)` should either be compatible with `ArrayAccess::offsetExists(mixed $offset): bool`, or the `#[\ReturnTypeWillChange]` attribute should be used to temporarily suppress the notice in `PROJECT_ROOT/vendor/telnyx/telnyx-php/lib/TelnyxObject.php` on line 186

Return type of `Telnyx\TelnyxObject::offsetGet($k)` should either be compatible with `ArrayAccess::offsetGet(mixed $offset): mixed`, or the `#[\ReturnTypeWillChange]` attribute should be used to temporarily suppress the notice in `PROJECT_ROOT/vendor/telnyx/telnyx-php/lib/TelnyxObject.php` on line 196

Return type of `Telnyx\TelnyxObject::offsetSet($k, $v)` should either be compatible with `ArrayAccess::offsetSet(mixed $offset, mixed $value): void`, or the `#[\ReturnTypeWillChange]` attribute should be used to temporarily suppress the notice in `PROJECT_ROOT/vendor/telnyx/telnyx-php/lib/TelnyxObject.php` on line 181

Return type of `Telnyx\TelnyxObject::offsetUnset($k)` should either be compatible with `ArrayAccess::offsetUnset(mixed $offset): void`, or the `#[\ReturnTypeWillChange]` attribute should be used to temporarily suppress the notice in `PROJECT_ROOT/vendor/telnyx/telnyx-php/lib/TelnyxObject.php` on line 191

Return type of `Telnyx\TelnyxObject::count()` should either be compatible with `Countable::count(): int`, or the `#[\ReturnTypeWillChange]` attribute should be used to temporarily suppress the notice in `PROJECT_ROOT/vendor/telnyx/telnyx-php/lib/TelnyxObject.php` on line 202

Return type of `Telnyx\TelnyxObject::jsonSerialize()` should either be compatible with `JsonSerializable::jsonSerialize(): mixed`, or the `#[\ReturnTypeWillChange]` attribute should be used to temporarily suppress the notice in `PROJECT_ROOT/vendor/telnyx/telnyx-php/lib/TelnyxObject.php` on line 409

...and so on.