### PR TITLE
Allow to passing required "verify_profile_id"

### DIFF
--- a/lib/Verification.php
+++ b/lib/Verification.php
@@ -43,6 +43,11 @@ class Verification extends ApiResource
     public static function submit_verification($phone_number, $verification_code, $options = null)
     {
         $params = ['code' => $verification_code];
+
+        if (!empty($options['verify_profile_id'])) {
+            $params['verify_profile_id'] = $options['verify_profile_id'];
+        }
+
         self::_validateParams($params);
         $url = '/v2/verifications/by_phone_number/' . urlencode($phone_number) . '/actions/verify';
 


### PR DESCRIPTION
Based on [API documentation](https://developers.telnyx.com/openapi/verify/tag/Verify/#tag/Verify/operation/verifyVerificationCode) the `verify_profile_id` is mandatory.

When following examples https://github.com/team-telnyx/telnyx-php/blob/master/examples/verify_sms_demo.php, I got an error message "A required parameter was missing".

This PR will allowing to pass `verify_profile_id` through 3rd-arguments, like so

```php
$verify_status = \Telnyx\Verification::submit_verification($phone_number, $verification_code, [
    'verify_profile_id' => $uuid,
]);
```
