### PR TITLE
fix: add --local flag so release-please scans next branch for commits

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -87,6 +87,7 @@ jobs:
             --target-branch master
             --config-file release-please-config.json
             --manifest-file .release-please-manifest.json
+            --local
           )
 
           if [ "${{ steps.version.outputs.has_version }}" = "true" ]; then


### PR DESCRIPTION
## Problem

Release-please runs on push to `next` but finds 0 commits and skips:
```
No commits for path: ., skipping
```

## Root Cause

release-please v17 (Google official) scans `master` for commits via API. But code changes are on `next`, not `master`. `--release-as` only sets the version number — it does NOT tell release-please where to find commits. The old `--changes-branch` flag was Stainless-only and does not exist in v17.

## Fix

Add `--local` flag to `release-pr` command. This makes release-please use the local checkout (which is `next` — the branch that triggered the workflow) instead of making API calls to scan `master`.

See Java PR #185 for the original root cause analysis. Same fix applied to all 6 SDKs.