### PR TITLE
ci(release): require manual merge of release PRs (remove auto-merge step)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -215,19 +215,3 @@ jobs:
             echo "::error::Merged release commit for $VER but no v$VER tag exists. github-release silently no-opped (merged release PR likely missing the autorelease pending label). Add the label to the merged PR and re-run this workflow."
             exit 1
           fi
-
-      - name: Enable auto-merge on release PRs
-        if: github.ref == 'refs/heads/next' && steps.release-pr.outputs.prs_created == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.SDK_WRITE_TOKEN }}
-          REPO: ${{ github.repository }}
-          PR_NUM: ${{ steps.release-pr.outputs.pr_number }}
-        run: |
-          if [ -n "$PR_NUM" ]; then
-            gh pr merge "$PR_NUM" --auto --squash --repo "$REPO" 2>/dev/null || echo "Auto-merge already enabled or PR #$PR_NUM not mergeable"
-          fi
-          sleep 3
-          prs=$(gh pr list --repo "$REPO" --state open --label "autorelease: pending" --json number --jq '.[].number')
-          for pr in $prs; do
-            gh pr merge "$pr" --auto --squash --repo "$REPO" 2>/dev/null || true
-          done


### PR DESCRIPTION
Per release-owner preference, release PRs should not merge themselves: remove the 'Enable auto-merge on release PRs' step. Release-please still opens/labels the PR and the ghost-release + label self-heal guards still apply; a human now reviews and merges each release PR, after which tagging and publishing proceed automatically as before.