### PR TITLE
ci: add workflow_dispatch to the release-please thin caller

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,6 +9,8 @@ on:
     branches:
       - next
       - master
+  # Manual retrigger (e.g. after a transient reusable-workflow failure).
+  workflow_dispatch: {}
 
 jobs:
   release-please:


### PR DESCRIPTION
One line: adds `workflow_dispatch` to the thin caller for manual retriggers.

**Merging this also heals the ghost 7.92.0**: release PR #343 merged at 15:19 but its release run failed at reusable-workflow resolution (telnyx-sdk-config had actions `access_level: none` — every thin-caller run since #345 failed this way; now set to `organization`). This merge's master push re-fires the github-release job, which finds the merged `autorelease: pending` PR and creates the v7.92.0 tag + Release (publish follows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)