### PR TITLE
ci: sync PHP release readiness to next

### DIFF
--- a/.github/scripts/release_pr_auto_merge.py
+++ b/.github/scripts/release_pr_auto_merge.py
@@ -171,6 +171,7 @@ class Attestation:
     head_sha: str
     base_sha: str
     next_sha: str
+    title: str
     version: str
     staging_sha: str
     config_sha: str
@@ -217,7 +218,7 @@ class ReleasePRAutoMergeGate:
         if dry_run:
             return {"status": "ready", "head_sha": first.head_sha, "dry_run": True}
 
-        self.client.merge(pr_number, first.head_sha)
+        self.client.merge(pr_number, first.head_sha, first.title)
         merged = self.client.read_merge_result(pr_number)
         merge_sha = merged.get("merge_commit_sha")
         if (
@@ -293,7 +294,15 @@ class ReleasePRAutoMergeGate:
         self._attest_tree(snapshot)
         staging_sha, config_sha = self._attest_provenance(snapshot, version)
         self._attest_checks(snapshot, head_sha)
-        return Attestation(head_sha, default_sha, next_sha, version, staging_sha, config_sha)
+        return Attestation(
+            head_sha,
+            default_sha,
+            next_sha,
+            "release: %s" % version,
+            version,
+            staging_sha,
+            config_sha,
+        )
 
     def _attest_tree(self, snapshot: Mapping[str, Any]) -> None:
         head_tree = self._tree(snapshot.get("head_tree"), "PR head tree")
@@ -386,6 +395,10 @@ class ReleasePRAutoMergeGate:
         expected: Dict[str, str] = dict(self.config.expected_checks)
         for context in live:
             self._require(isinstance(context, str) and context, "invalid live required context")
+            # This gate publishes release-provenance. Waiting for its own output
+            # would deadlock once the context becomes required.
+            if context == "release-provenance":
+                continue
             expected.setdefault(context, "github-actions")
 
         checks = snapshot.get("checks")
@@ -711,7 +724,7 @@ class GitHubClient:
                     raise GateError("invalid required-status context")
         return sorted(contexts)
 
-    def merge(self, pr_number: int, expected_head: str) -> None:
+    def merge(self, pr_number: int, expected_head: str, commit_title: str) -> None:
         merge_token = os.environ.get("MERGE_TOKEN")
         if not merge_token:
             raise GateError("MERGE_TOKEN is required for live merge")
@@ -731,6 +744,8 @@ class GitHubClient:
             "merge_method=squash",
             "--raw-field",
             "sha=%s" % expected_head,
+            "--raw-field",
+            "commit_title=%s" % commit_title,
         ]
         completed = subprocess.run(command, env=env, text=True, capture_output=True)
         if completed.returncode != 0:

--- a/.github/scripts/test_release_pr_auto_merge.py
+++ b/.github/scripts/test_release_pr_auto_merge.py
@@ -119,8 +119,8 @@ class FixtureClient:
     def read_snapshot(self, _pr_number):
         return copy.deepcopy(self.snapshot)
 
-    def merge(self, pr_number, expected_head):
-        self.merge_calls.append((pr_number, expected_head))
+    def merge(self, pr_number, expected_head, commit_title):
+        self.merge_calls.append((pr_number, expected_head, commit_title))
 
     def read_merge_result(self, _pr_number):
         return copy.deepcopy(self.merge_result)
@@ -157,6 +157,13 @@ class ReleasePRAutoMergeGateTests(unittest.TestCase):
         client = FixtureClient()
         result = self.gate(client).run(415, HEAD, True)
         self.assertEqual(result, {"status": "ready", "head_sha": HEAD, "dry_run": True})
+        self.assertEqual(client.merge_calls, [])
+
+    def test_required_release_provenance_does_not_wait_on_its_own_status(self):
+        client = FixtureClient()
+        client.snapshot["required_contexts"].append("release-provenance")
+        result = self.gate(client).run(415, HEAD, True)
+        self.assertEqual(result["status"], "ready")
         self.assertEqual(client.merge_calls, [])
 
     def test_config_inventory_contains_exactly_the_six_non_java_sdk_repositories(self):
@@ -325,7 +332,7 @@ class ReleasePRAutoMergeGateTests(unittest.TestCase):
     def test_live_mode_merges_only_the_attested_exact_head(self):
         client = FixtureClient()
         result = self.gate(client).run(415, HEAD, False)
-        self.assertEqual(client.merge_calls, [(415, HEAD)])
+        self.assertEqual(client.merge_calls, [(415, HEAD, "release: 4.174.0")])
         self.assertEqual(result["status"], "merged")
         self.assertEqual(result["merge_commit_sha"], MERGE)
 
@@ -381,6 +388,12 @@ class ReleasePRAutoMergeGateTests(unittest.TestCase):
         self.assertIn(
             "startsWith(github.event.pull_request.title, 'release: ')", workflow
         )
+        self.assertIn("github.event.pull_request.state == 'open'", workflow)
+        self.assertIn(
+            "github.event.label.name == 'autorelease: pending'", workflow
+        )
+        self.assertIn("  policy-test:\n", workflow)
+        self.assertNotIn("\n  test:\n", workflow)
 
     def test_merge_uses_immediate_rest_put_and_never_enables_auto_merge(self):
         client = GitHubClient(GateConfig.python(), "test-token")
@@ -392,7 +405,7 @@ class ReleasePRAutoMergeGateTests(unittest.TestCase):
         with mock.patch.dict("os.environ", {"MERGE_TOKEN": "test-token"}), mock.patch(
             "release_pr_auto_merge.subprocess.run", return_value=completed
         ) as run:
-            client.merge(415, HEAD)
+            client.merge(415, HEAD, "release: 4.174.0")
 
         command = run.call_args.args[0]
         self.assertEqual(
@@ -402,6 +415,7 @@ class ReleasePRAutoMergeGateTests(unittest.TestCase):
         self.assertIn("PUT", command)
         self.assertIn("merge_method=squash", command)
         self.assertIn("sha=%s" % HEAD, command)
+        self.assertIn("commit_title=release: 4.174.0", command)
         self.assertNotIn("pr", command)
 
 

--- a/.github/scripts/test_release_pr_ci_gate.py
+++ b/.github/scripts/test_release_pr_ci_gate.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Static contracts for DOT-2061 PHP phase 1."""
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class PHPReleasePRGateTests(unittest.TestCase):
+    def test_release_please_pr_runs_existing_full_jobs_without_suppressing_pushes(self):
+        ci = (ROOT / ".github/workflows/ci.yml").read_text()
+        self.assertEqual(ci.count("startsWith(github.head_ref, 'release-please--')"), 2)
+        self.assertIn("github.event_name == 'push'", ci)
+        for name in ("name: lint", "name: test"):
+            self.assertIn(name, ci)
+
+    def test_readiness_uses_trusted_default_policy_and_never_merges(self):
+        workflow = (ROOT / ".github/workflows/release-pr-readiness.yml").read_text()
+        self.assertIn("pull_request_target:", workflow)
+        self.assertIn("ref: ${{ github.event.repository.default_branch || 'master' }}", workflow)
+        self.assertIn("persist-credentials: false", workflow)
+        self.assertIn("--expected-head", workflow)
+        self.assertIn("--dry-run", workflow)
+        self.assertNotIn("--merge", workflow)
+
+    def test_readiness_publishes_exact_head_status_fail_closed(self):
+        workflow = (ROOT / ".github/workflows/release-pr-readiness.yml").read_text()
+        self.assertIn("context=release-provenance", workflow)
+        self.assertIn("state=pending", workflow)
+        self.assertIn("STATE=failure", workflow)
+        self.assertIn('[ "$STATE" = success ]', workflow)
+        self.assertIn("statuses: write", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,10 @@ jobs:
     timeout-minutes: 10
     name: lint
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
+    if: >-
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.fork ||
+      (github.event_name == 'pull_request' && startsWith(github.head_ref, 'release-please--'))
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -35,11 +38,19 @@ jobs:
       - name: Run lints
         run: ./scripts/lint
 
+      - name: Validate release gate policy
+        run: |
+          python3 .github/scripts/test_release_pr_auto_merge.py -v
+          python3 .github/scripts/test_release_pr_ci_gate.py -v
+
   test:
     timeout-minutes: 10
     name: test
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.pull_request.head.repo.fork
+    if: >-
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.fork ||
+      (github.event_name == 'pull_request' && startsWith(github.head_ref, 'release-please--'))
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/release-pr-auto-merge.yml
+++ b/.github/workflows/release-pr-auto-merge.yml
@@ -30,7 +30,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  policy-test:
+    name: policy-test
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -46,8 +47,10 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (
         github.event_name == 'pull_request_target' &&
+        github.event.pull_request.state == 'open' &&
         startsWith(github.event.pull_request.head.ref, 'release-please--') &&
-        startsWith(github.event.pull_request.title, 'release: ')
+        startsWith(github.event.pull_request.title, 'release: ') &&
+        (github.event.action != 'labeled' || github.event.label.name == 'autorelease: pending')
       )
     runs-on: ubuntu-latest
     timeout-minutes: 65

--- a/.github/workflows/release-pr-readiness.yml
+++ b/.github/workflows/release-pr-readiness.yml
@@ -1,0 +1,140 @@
+name: Exact-head release PR readiness
+
+on:
+  pull_request_target:
+    branches: [master]
+    types: [opened, reopened, synchronize, ready_for_review, labeled]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Release Please PR number
+        required: true
+        type: number
+      expected_head:
+        description: Exact 40-character PR head SHA
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: read
+  checks: read
+  statuses: write
+  actions: read
+
+concurrency:
+  group: release-pr-readiness-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  release-provenance:
+    name: release-provenance
+    runs-on: ubuntu-latest
+    timeout-minutes: 65
+    env:
+      EVENT_NAME: ${{ github.event_name }}
+      EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+      EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      EVENT_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+      EVENT_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+      EVENT_TITLE: ${{ github.event.pull_request.title }}
+      INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+      INPUT_EXPECTED_HEAD: ${{ inputs.expected_head }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Resolve immutable candidate
+        id: candidate
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            PR_NUMBER="$INPUT_PR_NUMBER"
+            HEAD_SHA="$INPUT_EXPECTED_HEAD"
+            CANDIDATE=true
+          else
+            PR_NUMBER="$EVENT_PR_NUMBER"
+            HEAD_SHA="$EVENT_HEAD_SHA"
+            if [[ "$EVENT_HEAD_REF" == release-please--* ]] && \
+               [[ "$EVENT_TITLE" == release:\ * ]] && \
+               [ "$EVENT_HEAD_REPOSITORY" = "$GITHUB_REPOSITORY" ]; then
+              CANDIDATE=true
+            else
+              CANDIDATE=false
+            fi
+          fi
+          if [[ ! "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Invalid immutable head SHA" >&2
+            exit 1
+          fi
+          {
+            echo "pr_number=$PR_NUMBER"
+            echo "head_sha=$HEAD_SHA"
+            echo "candidate=$CANDIDATE"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Mark non-release PR as not applicable
+        if: steps.candidate.outputs.candidate == 'false'
+        env:
+          HEAD_SHA: ${{ steps.candidate.outputs.head_sha }}
+        run: |
+          gh api "repos/$GITHUB_REPOSITORY/statuses/$HEAD_SHA" \
+            --method POST \
+            --raw-field state=success \
+            --raw-field context=release-provenance \
+            --raw-field description='Not a Release Please PR; provenance gate not applicable'
+
+      - name: Mark release provenance pending
+        if: steps.candidate.outputs.candidate == 'true'
+        env:
+          HEAD_SHA: ${{ steps.candidate.outputs.head_sha }}
+        run: |
+          gh api "repos/$GITHUB_REPOSITORY/statuses/$HEAD_SHA" \
+            --method POST \
+            --raw-field state=pending \
+            --raw-field context=release-provenance \
+            --raw-field description='Attesting exact release head and immutable lineage'
+
+      # pull_request_target executes trusted default-branch workflow code. Never
+      # checkout or execute the pull-request head in this privileged job.
+      - name: Check out trusted default-branch policy
+        if: steps.candidate.outputs.candidate == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.repository.default_branch || 'master' }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Attest exact release head without merging
+        id: attest
+        if: steps.candidate.outputs.candidate == 'true'
+        continue-on-error: true
+        env:
+          MERGE_TOKEN: ${{ secrets.SDK_WRITE_TOKEN }}
+          PR_NUMBER: ${{ steps.candidate.outputs.pr_number }}
+          HEAD_SHA: ${{ steps.candidate.outputs.head_sha }}
+        run: |
+          python3 .github/scripts/release_pr_auto_merge.py \
+            --pr-number "$PR_NUMBER" \
+            --expected-head "$HEAD_SHA" \
+            --dry-run
+
+      - name: Publish exact-head release provenance result
+        if: always() && steps.candidate.outputs.candidate == 'true'
+        env:
+          HEAD_SHA: ${{ steps.candidate.outputs.head_sha }}
+          OUTCOME: ${{ steps.attest.outcome }}
+        run: |
+          set -euo pipefail
+          if [ "$OUTCOME" = "success" ]; then
+            STATE=success
+            DESCRIPTION='Exact release head, lineage, metadata, and checks are ready'
+          else
+            STATE=failure
+            DESCRIPTION='Exact release readiness attestation failed closed'
+          fi
+          gh api "repos/$GITHUB_REPOSITORY/statuses/$HEAD_SHA" \
+            --method POST \
+            --raw-field state="$STATE" \
+            --raw-field context=release-provenance \
+            --raw-field description="$DESCRIPTION"
+          [ "$STATE" = success ]


### PR DESCRIPTION
## Summary
- sync validated PHP phase-1 readiness and exact-head attestor policy from master to next
- ensure the Release Please branch receives the same trusted policy
- replace the stale next copy of the disabled auto-merge workflow with the validated master copy

## Validation
- 25 attestor tests
- 3 phase-1 workflow contracts
- workflow YAML parse
- git diff --check