### PR TITLE
ci: make the PHP release PR the single full gate

### DIFF
--- a/.github/scripts/classify_production_ci.py
+++ b/.github/scripts/classify_production_ci.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+# ruff: noqa: T201
+# pyright: basic
+"""Classify production SDK CI events without weakening release validation.
+
+Unknown or unverifiable default-branch pushes always run the full suite. The only
+optimized default-branch case is an exact Release Please merge whose merged tree
+matches the validated PR head and whose expected exact-head checks succeeded.
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+import json
+import time
+import argparse
+import urllib.error
+import urllib.request
+from typing import Any, Mapping, Sequence, NamedTuple
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+VERSION_RE = re.compile(r"^release: [0-9]+\.[0-9]+\.[0-9]+$")
+SUCCESS_CONCLUSIONS = {"success"}
+
+
+class Decision(NamedTuple):
+    run_full: bool
+    mode: str
+    reason: str
+
+
+CHECKS: Mapping[str, Mapping[str, str]] = {
+    "team-telnyx/telnyx-python": {
+        "build": "github-actions", "lint": "github-actions", "test": "github-actions",
+        "protected-paths": "github-actions", "release doctor": "github-actions",
+        "Analyze (actions)": "github-actions", "Analyze (python)": "github-actions",
+        "CodeQL": "github-advanced-security", "release-provenance": "status",
+    },
+    "team-telnyx/telnyx-java": {
+        "build": "github-actions", "lint": "github-actions", "test": "github-actions",
+        "protected-paths": "github-actions", "release doctor": "github-actions",
+        "Analyze (actions)": "github-actions", "Analyze (java-kotlin)": "github-actions",
+        "CodeQL": "github-advanced-security", "release-provenance": "status",
+    },
+    "team-telnyx/telnyx-ruby": {
+        "lint (rubocop)": "github-actions", "lint (sorbet)": "github-actions",
+        "lint (steep)": "github-actions", "test": "github-actions",
+        "protected-paths": "github-actions", "release doctor": "github-actions",
+        "Analyze (actions)": "github-actions", "Analyze (ruby)": "github-actions",
+        "CodeQL": "github-advanced-security", "release-provenance": "status",
+    },
+    "team-telnyx/telnyx-go": {
+        "build": "github-actions", "lint": "github-actions", "test": "github-actions",
+        "protected-paths": "github-actions", "Analyze (actions)": "github-actions",
+        "Analyze (go)": "github-actions",
+        "CodeQL": "github-advanced-security", "release-provenance": "status",
+    },
+    "team-telnyx/telnyx-node": {
+        "build": "github-actions", "lint": "github-actions",
+        "protected-paths": "github-actions", "release doctor": "github-actions",
+        "Analyze (actions)": "github-actions",
+        "Analyze (javascript-typescript)": "github-actions",
+        "CodeQL": "github-advanced-security", "release-provenance": "status",
+    },
+    "team-telnyx/telnyx-php": {
+        "lint": "github-actions", "test": "github-actions",
+        "protected-paths": "github-actions", "release doctor": "github-actions",
+        "Analyze (actions)": "github-actions", "CodeQL": "github-advanced-security",
+        "release-provenance": "status",
+    },
+    "team-telnyx/telnyx-cli": {
+        "build": "github-actions", "lint": "github-actions", "test": "github-actions",
+        "protected-paths": "github-actions", "release doctor": "github-actions",
+        "Analyze (actions)": "github-actions", "Analyze (go)": "github-actions",
+        "CodeQL": "github-advanced-security", "release-provenance": "status",
+    },
+}
+
+
+class StaticAPI:
+    """Deterministic API implementation used by regression tests."""
+
+    def __init__(self, payloads: Mapping[str, Any]):
+        self.payloads = dict(payloads)
+
+    def get(self, path: str) -> Any:
+        if path not in self.payloads:
+            raise RuntimeError("unexpected API path: %s" % path)
+        return self.payloads[path]
+
+
+class GitHubAPI:
+    def __init__(self, token: str, attempts: int = 3, sleep=time.sleep):
+        if not token:
+            raise RuntimeError("GitHub token is required")
+        self.token = token
+        self.attempts = attempts
+        self.sleep = sleep
+
+    def get(self, path: str) -> Any:
+        url = "https://api.github.com/" + path.lstrip("/")
+        for attempt in range(self.attempts):
+            request = urllib.request.Request(
+                url,
+                headers={
+                    "Authorization": "Bearer " + self.token,
+                    "Accept": "application/vnd.github+json",
+                    "X-GitHub-Api-Version": "2022-11-28",
+                    "User-Agent": "telnyx-production-ci-classifier",
+                },
+            )
+            try:
+                with urllib.request.urlopen(request, timeout=30) as response:
+                    return json.loads(response.read().decode("utf-8"))
+            except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+                retryable = not isinstance(exc, urllib.error.HTTPError) or exc.code in {401, 408, 429, 500, 502, 503, 504}
+                if not retryable or attempt + 1 >= self.attempts:
+                    raise RuntimeError("GitHub API lookup failed") from exc
+                self.sleep(2 ** attempt)
+        raise RuntimeError("GitHub API lookup failed")
+
+
+class GitHubReleaseMergeVerifier:
+    def __init__(self, api: Any):
+        self.api = api
+
+    def is_verified_release_merge(self, repository: str, sha: str, default_branch: str) -> bool:
+        if repository not in CHECKS or not SHA_RE.fullmatch(sha):
+            return False
+        pulls = self.api.get("repos/%s/commits/%s/pulls?per_page=100" % (repository, sha))
+        if not isinstance(pulls, list):
+            return False
+        candidates = [pr for pr in pulls if self._is_release_merge(pr, sha, default_branch)]
+        if len(candidates) != 1:
+            return False
+        pr = candidates[0]
+        head = pr.get("head", {}).get("sha")
+        if not isinstance(head, str) or not SHA_RE.fullmatch(head):
+            return False
+
+        merged_commit = self.api.get("repos/%s/git/commits/%s" % (repository, sha))
+        head_commit = self.api.get("repos/%s/git/commits/%s" % (repository, head))
+        if self._tree(merged_commit) != self._tree(head_commit):
+            return False
+        return self._checks_succeeded(repository, head, CHECKS[repository])
+
+    @staticmethod
+    def _is_release_merge(pr: Any, sha: str, default_branch: str) -> bool:
+        return (
+            isinstance(pr, Mapping)
+            and pr.get("state") == "closed"
+            and bool(pr.get("merged_at"))
+            and pr.get("merge_commit_sha") == sha
+            and isinstance(pr.get("title"), str)
+            and bool(VERSION_RE.fullmatch(pr["title"]))
+            and isinstance(pr.get("base"), Mapping)
+            and pr["base"].get("ref") == default_branch
+            and isinstance(pr.get("head"), Mapping)
+            and isinstance(pr["head"].get("ref"), str)
+            and pr["head"]["ref"].startswith("release-please--")
+        )
+
+    @staticmethod
+    def _tree(commit: Any) -> str:
+        if not isinstance(commit, Mapping) or not isinstance(commit.get("tree"), Mapping):
+            return ""
+        tree = commit["tree"].get("sha")
+        return tree if isinstance(tree, str) and SHA_RE.fullmatch(tree) else ""
+
+    def _checks_succeeded(self, repository: str, head: str, expected: Mapping[str, str]) -> bool:
+        check_payload = self.api.get("repos/%s/commits/%s/check-runs?per_page=100" % (repository, head))
+        status_payload = self.api.get("repos/%s/commits/%s/status" % (repository, head))
+        if not isinstance(check_payload, Mapping) or not isinstance(check_payload.get("check_runs"), list):
+            return False
+        if not isinstance(status_payload, Mapping) or not isinstance(status_payload.get("statuses"), list):
+            return False
+
+        latest_checks: dict[str, Mapping[str, Any]] = {}
+        ordered = sorted(
+            (run for run in check_payload["check_runs"] if isinstance(run, Mapping)),
+            key=lambda run: str(run.get("completed_at") or run.get("started_at") or ""),
+            reverse=True,
+        )
+        for run in ordered:
+            name = run.get("name")
+            if isinstance(name, str) and name not in latest_checks:
+                latest_checks[name] = run
+
+        latest_statuses: dict[str, Mapping[str, Any]] = {}
+        for status in status_payload["statuses"]:
+            if isinstance(status, Mapping) and isinstance(status.get("context"), str):
+                latest_statuses.setdefault(status["context"], status)
+
+        for name, source in expected.items():
+            if source == "status":
+                if latest_statuses.get(name, {}).get("state") != "success":
+                    return False
+                continue
+            run = latest_checks.get(name)
+            if not run or run.get("status") != "completed" or run.get("conclusion") not in SUCCESS_CONCLUSIONS:
+                return False
+            app = run.get("app")
+            if not isinstance(app, Mapping) or app.get("slug") != source:
+                return False
+        return True
+
+
+def classify_event(event: Mapping[str, Any], verifier: Any) -> Decision:
+    repository_data = event.get("repository")
+    if not isinstance(repository_data, Mapping):
+        return Decision(True, "ordinary_push_full", "repository metadata unavailable")
+    repository = repository_data.get("full_name")
+    default_branch = repository_data.get("default_branch")
+    if not isinstance(repository, str) or not isinstance(default_branch, str):
+        return Decision(True, "ordinary_push_full", "repository metadata unavailable")
+
+    event_name = event.get("event_name")
+    if event_name == "pull_request":
+        pull = event.get("pull_request")
+        head_ref = pull.get("head", {}).get("ref") if isinstance(pull, Mapping) else ""
+        mode = "release_pr_full" if isinstance(head_ref, str) and head_ref.startswith("release-please--") else "ordinary_pr_full"
+        return Decision(True, mode, "pull requests are full validation surfaces")
+    if event_name != "push":
+        return Decision(True, "ordinary_push_full", "unknown event runs full CI")
+
+    ref = event.get("ref")
+    branch = ref[len("refs/heads/"):] if isinstance(ref, str) and ref.startswith("refs/heads/") else ""
+    if branch == "next":
+        return Decision(False, "next_lightweight", "next uses immutable production-lineage validation")
+    if branch.startswith("release-please--"):
+        return Decision(False, "release_branch_push_lightweight", "release PR event owns the full suite")
+    if branch != default_branch:
+        return Decision(True, "ordinary_push_full", "ordinary branch push")
+
+    sha = event.get("after")
+    try:
+        verified = isinstance(sha, str) and verifier.is_verified_release_merge(repository, sha, default_branch)
+    except Exception:
+        return Decision(True, "ordinary_push_full", "release verification unavailable; running full CI")
+    if verified:
+        return Decision(False, "verified_release_merge_lightweight", "exact validated release head/tree was merged")
+    return Decision(True, "ordinary_push_full", "default push was not a proven release merge")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--event-path", required=True)
+    args = parser.parse_args(argv)
+    try:
+        with open(args.event_path, encoding="utf-8") as handle:
+            event = json.load(handle)
+        event["event_name"] = os.environ.get("GITHUB_EVENT_NAME", event.get("event_name", ""))
+        token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+        verifier = GitHubReleaseMergeVerifier(GitHubAPI(token)) if token else StaticAPI({})
+        decision = classify_event(event, verifier)
+    except Exception as exc:
+        decision = Decision(True, "ordinary_push_full", "classifier error; running full CI")
+        sys.stderr.write("classifier warning: %s\n" % type(exc).__name__)
+
+    output = os.environ.get("GITHUB_OUTPUT")
+    if output:
+        with open(output, "a", encoding="utf-8") as handle:
+            handle.write("run_full=%s\n" % str(decision.run_full).lower())
+            handle.write("mode=%s\n" % decision.mode)
+            handle.write("reason=%s\n" % decision.reason.replace("\n", " "))
+    print(json.dumps(decision._asdict(), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_classify_production_ci.py
+++ b/.github/scripts/test_classify_production_ci.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+# pyright: basic
+from __future__ import annotations
+
+import unittest
+import importlib.util
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).with_name("classify_production_ci.py")
+spec = importlib.util.spec_from_file_location("classify_production_ci", MODULE_PATH)
+assert spec and spec.loader
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+
+class FakeVerifier:
+    def __init__(self, result=False, error=None):
+        self.result = result
+        self.error = error
+        self.calls = []
+
+    def is_verified_release_merge(self, repository, sha, default_branch):
+        self.calls.append((repository, sha, default_branch))
+        if self.error:
+            raise self.error
+        return self.result
+
+
+def push(branch, sha="a" * 40, message="ordinary commit"):
+    return {
+        "event_name": "push",
+        "ref": f"refs/heads/{branch}",
+        "after": sha,
+        "repository": {"full_name": "team-telnyx/telnyx-cli", "default_branch": "main"},
+        "head_commit": {"message": message},
+    }
+
+
+class ClassificationTests(unittest.TestCase):
+    def test_release_pr_runs_full_ci(self):
+        event = {
+            "event_name": "pull_request",
+            "pull_request": {
+                "head": {"ref": "release-please--branches--main"},
+                "base": {"ref": "main"},
+            },
+            "repository": {"full_name": "team-telnyx/telnyx-cli", "default_branch": "main"},
+        }
+        decision = module.classify_event(event, FakeVerifier())
+        self.assertTrue(decision.run_full)
+        self.assertEqual("release_pr_full", decision.mode)
+
+    def test_ordinary_pr_runs_full_ci(self):
+        event = {
+            "event_name": "pull_request",
+            "pull_request": {"head": {"ref": "fix/example"}, "base": {"ref": "main"}},
+            "repository": {"full_name": "team-telnyx/telnyx-cli", "default_branch": "main"},
+        }
+        decision = module.classify_event(event, FakeVerifier())
+        self.assertTrue(decision.run_full)
+        self.assertEqual("ordinary_pr_full", decision.mode)
+
+    def test_next_push_is_lightweight(self):
+        decision = module.classify_event(push("next"), FakeVerifier())
+        self.assertFalse(decision.run_full)
+        self.assertEqual("next_lightweight", decision.mode)
+
+    def test_release_branch_push_is_deduplicated(self):
+        decision = module.classify_event(push("release-please--branches--main"), FakeVerifier())
+        self.assertFalse(decision.run_full)
+        self.assertEqual("release_branch_push_lightweight", decision.mode)
+
+    def test_verified_release_merge_skips_duplicate_full_ci(self):
+        verifier = FakeVerifier(result=True)
+        decision = module.classify_event(push("main"), verifier)
+        self.assertFalse(decision.run_full)
+        self.assertEqual("verified_release_merge_lightweight", decision.mode)
+        self.assertEqual(1, len(verifier.calls))
+
+    def test_unverified_default_push_runs_full_ci(self):
+        decision = module.classify_event(push("main"), FakeVerifier(result=False))
+        self.assertTrue(decision.run_full)
+        self.assertEqual("ordinary_push_full", decision.mode)
+
+    def test_api_failure_fails_safe_to_full_ci(self):
+        decision = module.classify_event(push("main"), FakeVerifier(error=RuntimeError("503")))
+        self.assertTrue(decision.run_full)
+        self.assertEqual("ordinary_push_full", decision.mode)
+        self.assertIn("verification unavailable", decision.reason)
+
+    def test_other_branch_push_runs_full_ci(self):
+        decision = module.classify_event(push("feature/example"), FakeVerifier())
+        self.assertTrue(decision.run_full)
+        self.assertEqual("ordinary_push_full", decision.mode)
+
+
+class ReleaseMergeVerifierTests(unittest.TestCase):
+    def make_api(self, *, tree_match=True, missing_check=None, ambiguous=False):
+        sha = "a" * 40
+        head = "b" * 40
+        checks = [
+            ("build", "github-actions"),
+            ("lint", "github-actions"),
+            ("test", "github-actions"),
+            ("protected-paths", "github-actions"),
+            ("release doctor", "github-actions"),
+            ("Analyze (actions)", "github-actions"),
+            ("Analyze (go)", "github-actions"),
+            ("CodeQL", "github-advanced-security"),
+        ]
+        runs = [
+            {
+                "name": name,
+                "status": "completed",
+                "conclusion": "success",
+                "app": {"slug": app},
+                "completed_at": "2026-08-17T22:00:00Z",
+            }
+            for name, app in checks
+            if name != missing_check
+        ]
+        pull = {
+            "number": 85,
+            "state": "closed",
+            "merged_at": "2026-08-17T22:00:00Z",
+            "merge_commit_sha": sha,
+            "title": "release: 0.28.0",
+            "base": {"ref": "main"},
+            "head": {"ref": "release-please--branches--main", "sha": head},
+        }
+        pulls = [pull, dict(pull, number=86)] if ambiguous else [pull]
+        payloads = {
+            f"repos/team-telnyx/telnyx-cli/commits/{sha}/pulls?per_page=100": pulls,
+            f"repos/team-telnyx/telnyx-cli/git/commits/{sha}": {"tree": {"sha": "c" * 40}},
+            f"repos/team-telnyx/telnyx-cli/git/commits/{head}": {
+                "tree": {"sha": ("c" if tree_match else "d") * 40}
+            },
+            f"repos/team-telnyx/telnyx-cli/commits/{head}/check-runs?per_page=100": {
+                "check_runs": runs
+            },
+            f"repos/team-telnyx/telnyx-cli/commits/{head}/status": {
+                "statuses": [{"context": "release-provenance", "state": "success"}]
+            },
+        }
+        return module.StaticAPI(payloads), sha
+
+    def test_exact_release_merge_with_exact_head_checks_is_verified(self):
+        api, sha = self.make_api()
+        verifier = module.GitHubReleaseMergeVerifier(api)
+        self.assertTrue(verifier.is_verified_release_merge("team-telnyx/telnyx-cli", sha, "main"))
+
+    def test_ambiguous_associated_release_prs_fail_closed(self):
+        api, sha = self.make_api(ambiguous=True)
+        verifier = module.GitHubReleaseMergeVerifier(api)
+        self.assertFalse(verifier.is_verified_release_merge("team-telnyx/telnyx-cli", sha, "main"))
+
+    def test_tree_mismatch_fails_closed(self):
+        api, sha = self.make_api(tree_match=False)
+        verifier = module.GitHubReleaseMergeVerifier(api)
+        self.assertFalse(verifier.is_verified_release_merge("team-telnyx/telnyx-cli", sha, "main"))
+
+    def test_missing_required_check_fails_closed(self):
+        api, sha = self.make_api(missing_check="test")
+        verifier = module.GitHubReleaseMergeVerifier(api)
+        self.assertFalse(verifier.is_verified_release_merge("team-telnyx/telnyx-cli", sha, "main"))
+
+    def test_non_success_release_provenance_status_fails_closed(self):
+        api, sha = self.make_api()
+        api.payloads[f"repos/team-telnyx/telnyx-cli/commits/{'b' * 40}/status"] = {
+            "statuses": [{"context": "release-provenance", "state": "pending"}]
+        }
+        verifier = module.GitHubReleaseMergeVerifier(api)
+        self.assertFalse(verifier.is_verified_release_merge("team-telnyx/telnyx-cli", sha, "main"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_release_pr_ci_gate.py
+++ b/.github/scripts/test_release_pr_ci_gate.py
@@ -1,36 +1,46 @@
 #!/usr/bin/env python3
-"""Static contracts for DOT-2061 PHP phase 1."""
+"""Static contracts for DOT-2061 PHP phase 2."""
 import unittest
 from pathlib import Path
-
 ROOT = Path(__file__).resolve().parents[2]
 
-
 class PHPReleasePRGateTests(unittest.TestCase):
-    def test_release_please_pr_runs_existing_full_jobs_without_suppressing_pushes(self):
-        ci = (ROOT / ".github/workflows/ci.yml").read_text()
-        self.assertEqual(ci.count("startsWith(github.head_ref, 'release-please--')"), 2)
-        self.assertIn("github.event_name == 'push'", ci)
-        for name in ("name: lint", "name: test"):
-            self.assertIn(name, ci)
+    def test_classifier_owns_every_full_ci_job(self):
+        ci=(ROOT/'.github/workflows/ci.yml').read_text()
+        self.assertIn('name: classify production CI',ci)
+        self.assertIn('classify_production_ci.py --event-path',ci)
+        self.assertNotIn('>> "$GITHUB_OUTPUT"',ci)
+        self.assertEqual(ci.count('needs: classify-production-ci'),2)
+        self.assertEqual(ci.count("if: needs.classify-production-ci.outputs.run_full == 'true'"),2)
+        for test in ('test_release_pr_auto_merge.py','test_release_pr_ci_gate.py','test_classify_production_ci.py','test_validate_next_provenance.py','test_verify_packagist_release.py'):
+            self.assertIn(test,ci)
 
-    def test_readiness_uses_trusted_default_policy_and_never_merges(self):
-        workflow = (ROOT / ".github/workflows/release-pr-readiness.yml").read_text()
-        self.assertIn("pull_request_target:", workflow)
-        self.assertIn("ref: ${{ github.event.repository.default_branch || 'master' }}", workflow)
-        self.assertIn("persist-credentials: false", workflow)
-        self.assertIn("--expected-head", workflow)
-        self.assertIn("--dry-run", workflow)
-        self.assertNotIn("--merge", workflow)
+    def test_next_readiness_is_lightweight_and_fail_closed(self):
+        w=(ROOT/'.github/workflows/next-readiness.yml').read_text()
+        self.assertIn('branches: [next]',w)
+        self.assertIn('name: next-readiness',w)
+        self.assertIn('validate_next_provenance.py',w)
+        self.assertIn('--expected-next',w)
+        self.assertIn('MERGE_TOKEN: ${{ secrets.SDK_WRITE_TOKEN }}',w)
+        self.assertIn('persist-credentials: false',w)
+        self.assertNotIn('./scripts/lint',w)
+        self.assertNotIn('./scripts/test',w)
 
-    def test_readiness_publishes_exact_head_status_fail_closed(self):
-        workflow = (ROOT / ".github/workflows/release-pr-readiness.yml").read_text()
-        self.assertIn("context=release-provenance", workflow)
-        self.assertIn("state=pending", workflow)
-        self.assertIn("STATE=failure", workflow)
-        self.assertIn('[ "$STATE" = success ]', workflow)
-        self.assertIn("statuses: write", workflow)
+    def test_release_workflow_verifies_exact_packagist_version(self):
+        w=(ROOT/'.github/workflows/release-please.yml').read_text()
+        self.assertIn('name: Verify Packagist release availability',w)
+        self.assertIn('verify_packagist_release.py',w)
+        self.assertIn('--version "$VERSION"',w)
+        self.assertIn('--release-sha "$RELEASE_SHA"',w)
+        self.assertNotIn('release-pr-auto-merge.yml',w)
 
+    def test_readiness_remains_trusted_dry_run(self):
+        w=(ROOT/'.github/workflows/release-pr-readiness.yml').read_text()
+        self.assertIn('pull_request_target:',w)
+        self.assertIn("default_branch || 'master'",w)
+        self.assertIn('persist-credentials: false',w)
+        self.assertIn('--expected-head',w)
+        self.assertIn('--dry-run',w)
+        self.assertNotIn('--merge',w)
 
-if __name__ == "__main__":
-    unittest.main()
+if __name__=='__main__': unittest.main()

--- a/.github/scripts/test_validate_next_provenance.py
+++ b/.github/scripts/test_validate_next_provenance.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# pyright: basic
+import unittest
+
+from release_pr_auto_merge import GateError
+from validate_next_provenance import (
+    PRODUCTION_POLICY_PATHS,
+    api_tree,
+    changed_paths,
+    require_policy_parity,
+    require_only_allowed_changes,
+)
+
+A = ("100644", "blob", "a" * 40)
+B = ("100644", "blob", "b" * 40)
+
+
+class PHPNextProvenanceTests(unittest.TestCase):
+    def test_generated_tree_change_is_rejected(self):
+        with self.assertRaisesRegex(GateError, "src/generated.go"):
+            require_only_allowed_changes(
+                {"src/generated.go": A},
+                {"src/generated.go": B},
+                {".github/workflows/ci.yml"},
+                "promotion",
+            )
+
+    def test_only_enumerated_production_transform_is_allowed(self):
+        require_only_allowed_changes(
+            {"src/generated.go": A, "go.mod": A},
+            {"src/generated.go": A, "go.mod": B},
+            {"go.mod"},
+            "promotion",
+        )
+
+    def test_add_delete_and_modify_are_all_detected(self):
+        self.assertEqual(
+            changed_paths({"same": A, "deleted": A, "changed": A}, {"same": A, "added": B, "changed": B}),
+            {"deleted", "added", "changed"},
+        )
+
+    def test_policy_must_exist_and_match_default_exactly(self):
+        with self.assertRaisesRegex(GateError, "ci.yml"):
+            require_policy_parity(
+                {".github/workflows/ci.yml": A},
+                {},
+                {".github/workflows/ci.yml"},
+            )
+        with self.assertRaisesRegex(GateError, "ci.yml"):
+            require_policy_parity({}, {}, {".github/workflows/ci.yml"})
+        require_policy_parity(
+            {path: A for path in PRODUCTION_POLICY_PATHS},
+            {path: A for path in PRODUCTION_POLICY_PATHS},
+            PRODUCTION_POLICY_PATHS,
+        )
+
+    def test_truncated_or_malformed_api_tree_fails_closed(self):
+        with self.assertRaisesRegex(GateError, "truncated"):
+            api_tree({"truncated": True, "tree": []})
+        with self.assertRaisesRegex(GateError, "invalid staging tree entry"):
+            api_tree({"truncated": False, "tree": [{"path": "x"}]})
+
+    def test_api_tree_keeps_only_blob_identity(self):
+        payload = {
+            "truncated": False,
+            "tree": [
+                {"path": "x", "mode": "100644", "type": "blob", "sha": "a" * 40},
+                {"path": "dir", "mode": "040000", "type": "tree", "sha": "b" * 40},
+            ],
+        }
+        self.assertEqual(api_tree(payload), {"x": A})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_verify_packagist_release.py
+++ b/.github/scripts/test_verify_packagist_release.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+import unittest
+from verify_packagist_release import GateError, validate_packagist_payload
+SHA='a'*40
+class PackagistReleaseTests(unittest.TestCase):
+    def payload(self,version='7.98.0',reference=SHA):
+        return {'packages':{'telnyx/telnyx-php':[{'version':version,'version_normalized':version+'.0','source':{'type':'git','url':'https://github.com/team-telnyx/telnyx-php.git','reference':reference},'dist':{'type':'zip','url':'https://api.github.com/repos/team-telnyx/telnyx-php/zipball/'+reference,'reference':reference}}]}}
+    def test_exact_version_and_reference_pass(self):
+        validate_packagist_payload(self.payload(),'telnyx/telnyx-php','7.98.0',SHA)
+    def test_missing_version_fails_closed(self):
+        with self.assertRaisesRegex(GateError,'version'): validate_packagist_payload(self.payload('7.97.0'),'telnyx/telnyx-php','7.98.0',SHA)
+    def test_wrong_source_reference_fails_closed(self):
+        with self.assertRaisesRegex(GateError,'reference'): validate_packagist_payload(self.payload(reference='b'*40),'telnyx/telnyx-php','7.98.0',SHA)
+    def test_malformed_payload_fails_closed(self):
+        with self.assertRaisesRegex(GateError,'payload'): validate_packagist_payload({},'telnyx/telnyx-php','7.98.0',SHA)
+if __name__=='__main__': unittest.main()

--- a/.github/scripts/validate_next_provenance.py
+++ b/.github/scripts/validate_next_provenance.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+# ruff: noqa: T201
+# pyright: basic
+"""Fail-closed lightweight provenance/tree gate for production `next`.
+
+This runs from repository-owned workflow code. It binds the exact hosted `next`
+ref to the latest first-parent staging promotion, reuses the release attestor's
+immutable staging/config provenance checks, proves generated files equal the
+promoted staging tree, and permits only enumerated production-owned transforms.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import argparse
+import subprocess
+from typing import Set, Dict, Tuple, Mapping, Iterable
+
+from release_pr_auto_merge import (
+    SHA_RE,
+    CONFIG_URL_RE,
+    RELEASE_AS_RE,
+    GateError,
+    GateConfig,
+    GitHubClient,
+    ReleasePRAutoMergeGate,
+)
+
+TreeEntry = Tuple[str, str, str]
+
+PRODUCTION_POLICY_PATHS = frozenset(
+    {
+        ".github/scripts/classify_production_ci.py",
+        ".github/scripts/release_pr_auto_merge.py",
+        ".github/scripts/test_classify_production_ci.py",
+        ".github/scripts/test_release_pr_auto_merge.py",
+        ".github/scripts/test_release_pr_ci_gate.py",
+        ".github/scripts/test_validate_next_provenance.py",
+        ".github/scripts/test_verify_packagist_release.py",
+        ".github/scripts/validate_next_provenance.py",
+        ".github/scripts/verify_packagist_release.py",
+        ".github/workflows/ci.yml",
+        ".github/workflows/next-readiness.yml",
+        ".github/workflows/release-doctor.yml",
+        ".github/workflows/release-please.yml",
+        ".github/workflows/release-pr-auto-merge.yml",
+        ".github/workflows/release-pr-guard.yml",
+        ".github/workflows/release-pr-readiness.yml",
+        "bin/check-release-environment",
+        "release-please-config.json",
+    }
+)
+
+STAGING_ONLY_PATHS = frozenset(
+    {
+        ".github/scripts/attest-staging-promotion.py",
+        ".github/scripts/test_attest_staging_promotion.py",
+        ".github/scripts/test_promote_to_prod_contract.py",
+        ".github/workflows/promote-to-prod.yml",
+    }
+)
+
+# PHP promotion restores CODEOWNERS from production in addition to release
+# metadata and the policy inventory above.
+PROMOTION_TRANSFORM_PATHS = frozenset({".github/CODEOWNERS"})
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise GateError(message)
+
+
+def changed_paths(left: Mapping[str, TreeEntry], right: Mapping[str, TreeEntry]) -> Set[str]:
+    return {path for path in set(left) | set(right) if left.get(path) != right.get(path)}
+
+
+def require_only_allowed_changes(
+    left: Mapping[str, TreeEntry], right: Mapping[str, TreeEntry], allowed: Iterable[str], label: str
+) -> None:
+    unexpected = sorted(changed_paths(left, right) - set(allowed))
+    _require(not unexpected, "%s changed non-allowed paths: %s" % (label, ", ".join(unexpected)))
+
+
+def require_policy_parity(
+    default_tree: Mapping[str, TreeEntry], next_tree: Mapping[str, TreeEntry], policy_paths: Iterable[str]
+) -> None:
+    drift = sorted(
+        path
+        for path in policy_paths
+        if default_tree.get(path) is None or default_tree.get(path) != next_tree.get(path)
+    )
+    _require(not drift, "next production policy differs from default: %s" % ", ".join(drift))
+
+
+def api_tree(payload: Mapping[str, object]) -> Dict[str, TreeEntry]:
+    _require(payload.get("truncated") is False, "staging tree response was truncated")
+    entries = payload.get("tree")
+    if not isinstance(entries, list):
+        raise GateError("invalid staging tree payload")
+    result: Dict[str, TreeEntry] = {}
+    for raw in entries:
+        _require(isinstance(raw, Mapping), "invalid staging tree entry")
+        path, mode, kind, sha = raw.get("path"), raw.get("mode"), raw.get("type"), raw.get("sha")
+        _require(all(isinstance(value, str) and value for value in (path, mode, kind, sha)), "invalid staging tree entry")
+        if kind == "blob":
+            result[str(path)] = (str(mode), str(kind), str(sha))
+    return result
+
+
+def fetch_exact_production_refs(config: GateConfig, default_sha: str, next_sha: str) -> None:
+    completed = subprocess.run(
+        [
+            "git", "fetch", "--force", "--no-tags", "origin",
+            "refs/heads/%s:refs/remotes/origin/audited-default" % config.default_branch,
+            "refs/heads/next:refs/remotes/origin/audited-next",
+        ],
+        text=True,
+        capture_output=True,
+    )
+    _require(completed.returncode == 0, "could not fetch production audit refs")
+    for ref, expected in {
+        "refs/remotes/origin/audited-default": default_sha,
+        "refs/remotes/origin/audited-next": next_sha,
+    }.items():
+        resolved = subprocess.run(["git", "rev-parse", "--verify", ref], text=True, capture_output=True)
+        _require(resolved.returncode == 0 and resolved.stdout.strip() == expected, "production audit ref drift: %s" % ref)
+
+
+def validate(repository: str, expected_next: str, token: str) -> Tuple[str, str]:
+    _require(SHA_RE.fullmatch(expected_next) is not None, "invalid expected next SHA")
+    config = GateConfig.for_repository(repository)
+    client = GitHubClient(config, token)
+
+    default_ref = client._api_json("repos/%s/git/ref/heads/%s" % (repository, config.default_branch))
+    next_ref = client._api_json("repos/%s/git/ref/heads/next" % repository)
+    default_sha = str(default_ref.get("object", {}).get("sha", ""))
+    current_next = str(next_ref.get("object", {}).get("sha", ""))
+    _require(SHA_RE.fullmatch(default_sha) is not None, "invalid default ref SHA")
+    _require(current_next == expected_next, "hosted next ref differs from event SHA")
+
+    fetch_exact_production_refs(config, default_sha, current_next)
+    promotion = client._find_promotion(current_next)
+    promotion_sha = str(promotion.get("sha", ""))
+    staging_sha = str(promotion.get("staging_sha", ""))
+    _require(SHA_RE.fullmatch(promotion_sha) is not None, "invalid promotion SHA")
+    _require(SHA_RE.fullmatch(staging_sha) is not None, "invalid staging SHA")
+
+    versions = RELEASE_AS_RE.findall(str(promotion.get("body", "")))
+    _require(len(versions) == 1, "promotion must contain exactly one Release-As trailer")
+    staging_prs = client._provenance_api_pages(
+        "repos/%s/commits/%s/pulls?per_page=100" % (config.staging_repository, staging_sha)
+    )
+    generated = client._find_generated_staging_pr(staging_sha, staging_prs)
+    config_urls = []
+    for source_pr in generated:
+        config_urls.extend(CONFIG_URL_RE.findall(str(source_pr.get("body") or "")))
+    _require(len(config_urls) == 1, "generated staging provenance must bind one config commit")
+    config_commit = client._provenance_api_json(
+        "repos/team-telnyx/telnyx-sdk-config/commits/%s" % config_urls[0]
+    )
+    resolved_config_sha = str(config_commit.get("sha", ""))
+
+    ReleasePRAutoMergeGate(config, client)._attest_provenance(
+        {
+            "promotion": promotion,
+            "staging_prs": staging_prs,
+            "generated_staging_prs": generated,
+            "generated_staging_reachable": True,
+            "resolved_config_sha": resolved_config_sha,
+        },
+        versions[0],
+    )
+
+    staging_payload = client._provenance_api_json(
+        "repos/%s/git/trees/%s?recursive=1" % (config.staging_repository, staging_sha)
+    )
+    staging_tree = api_tree(staging_payload)
+    promotion_tree = client._ls_tree(promotion_sha)
+    default_tree = client._ls_tree(default_sha)
+    next_tree = client._ls_tree(current_next)
+
+    promotion_allowed = (
+        set(PRODUCTION_POLICY_PATHS)
+        | set(STAGING_ONLY_PATHS)
+        | set(PROMOTION_TRANSFORM_PATHS)
+        | set(config.release_files)
+    )
+    require_only_allowed_changes(staging_tree, promotion_tree, promotion_allowed, "staging-to-promotion tree")
+    require_only_allowed_changes(
+        promotion_tree,
+        next_tree,
+        set(PRODUCTION_POLICY_PATHS) | set(config.release_files),
+        "post-promotion next tree",
+    )
+    require_policy_parity(default_tree, next_tree, PRODUCTION_POLICY_PATHS)
+    return staging_sha, resolved_config_sha
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--expected-next", required=True)
+    args = parser.parse_args()
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    _require(bool(token), "missing GitHub token")
+    staging_sha, config_sha = validate(args.repository, args.expected_next, str(token))
+    print("verified next provenance: staging=%s config=%s" % (staging_sha, config_sha))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except GateError as exc:
+        print("next readiness failed: %s" % exc, file=sys.stderr)
+        raise SystemExit(1) from exc

--- a/.github/scripts/verify_packagist_release.py
+++ b/.github/scripts/verify_packagist_release.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Verify exact PHP release availability through Packagist."""
+from __future__ import annotations
+import argparse,json,time,urllib.request,urllib.error
+from typing import Mapping,Any
+class GateError(RuntimeError): pass
+
+def validate_packagist_payload(payload:Mapping[str,Any],package:str,version:str,release_sha:str)->None:
+    packages=payload.get('packages')
+    if not isinstance(packages,dict) or not isinstance(packages.get(package),list): raise GateError('malformed Packagist payload')
+    wanted={version,'v'+version}
+    matches=[x for x in packages[package] if isinstance(x,dict) and x.get('version') in wanted]
+    if len(matches)!=1: raise GateError('Packagist version is missing or ambiguous: '+version)
+    item=matches[0]; source=item.get('source'); dist=item.get('dist')
+    if not isinstance(source,dict) or source.get('type')!='git' or source.get('reference')!=release_sha: raise GateError('Packagist source reference does not match exact release SHA')
+    if not isinstance(dist,dict) or dist.get('type')!='zip' or dist.get('reference')!=release_sha or not isinstance(dist.get('url'),str): raise GateError('Packagist dist reference does not match exact release SHA')
+
+def fetch(url:str)->Mapping[str,Any]:
+    req=urllib.request.Request(url,headers={'Accept':'application/json','User-Agent':'telnyx-release-verifier'})
+    with urllib.request.urlopen(req,timeout=30) as r:
+        data=json.load(r)
+    if not isinstance(data,dict): raise GateError('malformed Packagist payload')
+    return data
+
+def main()->int:
+    p=argparse.ArgumentParser(); p.add_argument('--package',default='telnyx/telnyx-php'); p.add_argument('--version',required=True); p.add_argument('--release-sha',required=True); p.add_argument('--attempts',type=int,default=12); p.add_argument('--delay',type=int,default=10); a=p.parse_args()
+    if len(a.release_sha)!=40 or any(c not in '0123456789abcdef' for c in a.release_sha): raise SystemExit('invalid release SHA')
+    url='https://repo.packagist.org/p2/%s.json'%a.package
+    last='not attempted'
+    for attempt in range(1,a.attempts+1):
+        try:
+            validate_packagist_payload(fetch(url),a.package,a.version,a.release_sha)
+            print('verified Packagist %s %s at %s'%(a.package,a.version,a.release_sha)); return 0
+        except (GateError,urllib.error.URLError,TimeoutError,OSError) as exc:
+            last=str(exc); print('Packagist verification attempt %d/%d: %s'%(attempt,a.attempts,last))
+            if attempt<a.attempts: time.sleep(a.delay)
+    raise SystemExit('Packagist release verification failed closed: '+last)
+if __name__=='__main__': raise SystemExit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,32 @@ on:
       - 'stl-preview-base/**'
 
 jobs:
+  classify-production-ci:
+    name: classify production CI
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: read
+      pull-requests: read
+      statuses: read
+    outputs:
+      run_full: ${{ steps.classify.outputs.run_full }}
+      reason: ${{ steps.classify.outputs.reason }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - id: classify
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 .github/scripts/classify_production_ci.py --event-path "$GITHUB_EVENT_PATH"
+
   lint:
+    needs: classify-production-ci
     timeout-minutes: 10
     name: lint
     runs-on: ubuntu-latest
-    if: >-
-      github.event_name == 'push' ||
-      github.event.pull_request.head.repo.fork ||
-      (github.event_name == 'pull_request' && startsWith(github.head_ref, 'release-please--'))
+    if: needs.classify-production-ci.outputs.run_full == 'true'
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -42,15 +60,16 @@ jobs:
         run: |
           python3 .github/scripts/test_release_pr_auto_merge.py -v
           python3 .github/scripts/test_release_pr_ci_gate.py -v
+          python3 .github/scripts/test_classify_production_ci.py -v
+          python3 .github/scripts/test_validate_next_provenance.py -v
+          python3 .github/scripts/test_verify_packagist_release.py -v
 
   test:
+    needs: classify-production-ci
     timeout-minutes: 10
     name: test
     runs-on: ubuntu-latest
-    if: >-
-      github.event_name == 'push' ||
-      github.event.pull_request.head.repo.fork ||
-      (github.event_name == 'pull_request' && startsWith(github.head_ref, 'release-please--'))
+    if: needs.classify-production-ci.outputs.run_full == 'true'
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/next-readiness.yml
+++ b/.github/workflows/next-readiness.yml
@@ -1,0 +1,57 @@
+name: Next lightweight readiness
+
+on:
+  push:
+    branches: [next]
+  workflow_dispatch:
+    inputs:
+      expected_next:
+        description: Exact 40-character next SHA to verify
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  FORCE_COLOR: "1"
+
+jobs:
+  next-readiness:
+    name: next-readiness
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Resolve exact next SHA
+        id: target
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PUSH_SHA: ${{ github.sha }}
+          DISPATCH_SHA: ${{ inputs.expected_next }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = workflow_dispatch ]; then
+            SHA="$DISPATCH_SHA"
+          else
+            SHA="$PUSH_SHA"
+          fi
+          if ! printf '%s' "$SHA" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo 'Expected next must be a full lowercase SHA' >&2
+            exit 1
+          fi
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ steps.target.outputs.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify immutable next provenance and tree
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MERGE_TOKEN: ${{ secrets.SDK_WRITE_TOKEN }}
+        run: |
+          python3 .github/scripts/validate_next_provenance.py \
+            --repository "$GITHUB_REPOSITORY" \
+            --expected-next "${{ steps.target.outputs.sha }}"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -293,29 +293,61 @@ jobs:
             --manifest-file .release-please-manifest.json \
             2>&1
 
-      - name: Verify release commit produced a tag (ghost-release guard)
+      - name: Verify release commit produced an exact tag (ghost-release guard)
         if: github.ref == 'refs/heads/master'
+        id: release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # `github-release` exits 0 even when it finds nothing to release ([]).
-          # If the commit that triggered this run is a merged `release: X.Y.Z`
-          # commit, a missing vX.Y.Z tag here means it silently no-opped —
-          # usually a merged release PR that lost its `autorelease: pending`
-          # label. Fail loud instead of ghosting the release.
+          set -euo pipefail
           MSG=$(git log -1 --format=%s "$GITHUB_SHA")
           VER=$(echo "$MSG" | grep -oP '^release:\s*\K[0-9][0-9.]*' || true)
           if [ -z "$VER" ]; then
+            echo "is_release=false" >> "$GITHUB_OUTPUT"
             echo "Not a release commit; nothing to verify"
             exit 0
           fi
-          if git ls-remote --exit-code --tags origin "v$VER" >/dev/null 2>&1; then
-            if ! gh api "repos/${{ github.repository }}/releases/tags/v$VER" >/dev/null 2>&1; then
-              echo "::error::Tag v$VER exists but there is no GitHub Release for it - the publish workflow (release: published) will never fire. Create it: gh release create v$VER --generate-notes"
-              exit 1
-            fi
-            echo "Tag v$VER and its GitHub Release exist - release verified"
-          else
-            echo "::error::Merged release commit for $VER but no v$VER tag exists. github-release silently no-opped (merged release PR likely missing the autorelease pending label). Add the label to the merged PR and re-run this workflow."
+
+          TAG="v$VER"
+          if ! git ls-remote --exit-code --tags origin "$TAG" >/dev/null 2>&1; then
+            echo "::error::Merged release commit for $VER but no $TAG tag exists"
             exit 1
           fi
+          if ! gh api "repos/${{ github.repository }}/releases/tags/$TAG" >/dev/null 2>&1; then
+            echo "::error::Tag $TAG exists but there is no GitHub Release"
+            exit 1
+          fi
+
+          TAG_OBJECT=$(gh api "repos/${{ github.repository }}/git/ref/tags/$TAG")
+          TAG_TYPE=$(jq -r '.object.type' <<<"$TAG_OBJECT")
+          TAG_SHA=$(jq -r '.object.sha' <<<"$TAG_OBJECT")
+          for _ in 1 2 3 4 5; do
+            [ "$TAG_TYPE" = commit ] && break
+            if [ "$TAG_TYPE" != tag ]; then
+              echo "::error::$TAG points to unsupported object type $TAG_TYPE"
+              exit 1
+            fi
+            TAG_OBJECT=$(gh api "repos/${{ github.repository }}/git/tags/$TAG_SHA")
+            TAG_TYPE=$(jq -r '.object.type' <<<"$TAG_OBJECT")
+            TAG_SHA=$(jq -r '.object.sha' <<<"$TAG_OBJECT")
+          done
+          if [ "$TAG_TYPE" != commit ] || [ "$TAG_SHA" != "$GITHUB_SHA" ]; then
+            echo "::error::$TAG resolves to ${TAG_TYPE}:${TAG_SHA}, expected commit:${GITHUB_SHA}"
+            exit 1
+          fi
+          {
+            echo "is_release=true"
+            echo "version=$VER"
+            echo "release_sha=$GITHUB_SHA"
+          } >> "$GITHUB_OUTPUT"
+          echo "Tag $TAG and its GitHub Release exist at exact commit $GITHUB_SHA"
+
+      - name: Verify Packagist release availability
+        if: github.ref == 'refs/heads/master' && steps.release.outputs.is_release == 'true'
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+          RELEASE_SHA: ${{ steps.release.outputs.release_sha }}
+        run: |
+          python3 .github/scripts/verify_packagist_release.py \
+            --version "$VERSION" \
+            --release-sha "$RELEASE_SHA"


### PR DESCRIPTION
## Summary
- classify production CI fail-closed so the exact Release Please PR is the sole full readiness surface
- add lightweight exact-provenance readiness on next
- verify exact tags and Packagist availability after publication

## Validation
- classifier, provenance, publication, attestor, and workflow contracts
- lint and full test suite
- live Packagist proof for 7.98.0
- workflow YAML parse and diff checks