### PR TITLE
fix: wait for authoritative release checks

### DIFF
--- a/.github/scripts/release_pr_auto_merge.py
+++ b/.github/scripts/release_pr_auto_merge.py
@@ -420,7 +420,14 @@ class ReleasePRAutoMergeGate:
             ]
             if successes:
                 continue
-            if any(check.get("status") != "completed" for check in candidates) or not candidates:
+            if (
+                not candidates
+                or any(check.get("status") != "completed" for check in candidates)
+                or all(check.get("conclusion") == "skipped" for check in candidates)
+            ):
+                # Lightweight push CI intentionally skips full checks. The
+                # authoritative pull-request run for the same exact head can
+                # arrive later, so keep polling without accepting the skip.
                 raise ChecksPending("required exact-head check pending or missing: %s" % name)
             raise GateError("required exact-head check failed: %s" % name)
 

--- a/.github/scripts/test_release_pr_auto_merge.py
+++ b/.github/scripts/test_release_pr_auto_merge.py
@@ -313,6 +313,20 @@ class ReleasePRAutoMergeGateTests(unittest.TestCase):
         self.assertEqual(result["status"], "ready")
         self.assertEqual(sleeps, [0])
 
+    def test_lightweight_skipped_check_waits_for_authoritative_success(self):
+        lightweight = FixtureClient.good_snapshot()
+        next(c for c in lightweight["checks"] if c["name"] == "build").update(
+            conclusion="skipped"
+        )
+        ready = FixtureClient.good_snapshot()
+        client = SequenceClient([lightweight, ready, ready])
+        sleeps = []
+
+        result = self.gate(client, attempts=2, sleeps=sleeps).run(415, HEAD, True)
+
+        self.assertEqual(result["status"], "ready")
+        self.assertEqual(sleeps, [0])
+
     def test_second_attestation_blocks_head_base_or_next_drift(self):
         mutations = {
             "head": lambda s: s["pr"]["head"].update(sha="7" * 40),


### PR DESCRIPTION
## Summary

- treat an exact-head required check whose only current runs are `skipped` as not authoritative yet
- keep polling for the full pull-request CI run on the same immutable head
- preserve fail-closed behavior for genuine terminal failures and bounded timeout behavior when no authoritative success arrives
- add a regression reproducing the lightweight-push-before-full-PR ordering seen on the cumulative release PR

## Root cause

Lightweight push CI intentionally emits completed `skipped` lint/test checks. The readiness gate saw those before the authoritative pull-request CI runs appeared and classified them as hard failures. Full CI later passed on the same head, but the failed `release-provenance` status was already published.

## Validation

- regression test failed before the implementation change with `required exact-head check failed`
- all repository release-policy Python tests pass
- Python compilation of the changed policy and test passes
- `git diff --check` passes

This PR changes production-owned release policy only. It does not merge or alter the cumulative Release Please PR.
