### PR TITLE
fix(release): preserve generated Composer state

### DIFF
--- a/.github/scripts/release_pr_auto_merge.py
+++ b/.github/scripts/release_pr_auto_merge.py
@@ -126,7 +126,7 @@ class GateConfig:
                 "default_branch": "master",
                 "staging_repository": "team-telnyx/telnyx-php-staging",
                 "release_files": {
-                    "CHANGELOG.md", "composer.json", "src/Version.php",
+                    "CHANGELOG.md", "src/Version.php",
                     ".release-please-manifest.json",
                 },
                 "checks": {

--- a/.github/scripts/test_release_pr_ci_gate.py
+++ b/.github/scripts/test_release_pr_ci_gate.py
@@ -34,6 +34,19 @@ class PHPReleasePRGateTests(unittest.TestCase):
         self.assertIn('--release-sha "$RELEASE_SHA"',w)
         self.assertNotIn('release-pr-auto-merge.yml',w)
 
+    def test_release_sync_preserves_generated_composer_state(self):
+        w=(ROOT/'.github/workflows/release-please.yml').read_text()
+        release_files = 'RELEASE_FILES=("CHANGELOG.md" "src/Version.php" ".release-please-manifest.json")'
+        reconcile_loop = 'for f in CHANGELOG.md src/Version.php .release-please-manifest.json; do'
+        self.assertIn(release_files, w)
+        self.assertGreaterEqual(w.count(reconcile_loop), 2)
+        self.assertNotIn('RELEASE_FILES=("CHANGELOG.md" "composer.json"', w)
+        self.assertNotIn('for f in CHANGELOG.md composer.json', w)
+        self.assertIn('git diff --quiet origin/next -- composer.json composer.lock', w)
+
+        from release_pr_auto_merge import GateConfig
+        self.assertNotIn('composer.json', GateConfig.for_repository('team-telnyx/telnyx-php').release_files)
+
     def test_readiness_remains_trusted_dry_run(self):
         w=(ROOT/'.github/workflows/release-pr-readiness.yml').read_text()
         self.assertIn('pull_request_target:',w)

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -88,7 +88,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          RELEASE_FILES=("CHANGELOG.md" "composer.json" "src/Version.php" ".release-please-manifest.json")
+          # composer.json and composer.lock are generated SDK state. Only release
+          # metadata may be restored from production while scanning next.
+          RELEASE_FILES=("CHANGELOG.md" "src/Version.php" ".release-please-manifest.json")
           git restore --source=refs/remotes/origin/release-base --staged --worktree -- "${RELEASE_FILES[@]}"
           SCAN_TREE=$(git write-tree)
           PROMOTE_SUBJECT=$(git log --format=%s --max-count=50 HEAD \
@@ -154,7 +156,7 @@ jobs:
           PR_NUM: ${{ steps.release-pr.outputs.pr_number }}
         run: |
           # release-please creates a PR with only version bumps (CHANGELOG,
-          # composer.json, Version.php, CHANGELOG.md, .release-please-manifest.json).
+          # Version.php and .release-please-manifest.json).
           # The actual SDK code changes are on `next` but NOT included in the
           # release PR. This step syncs `next` code into the release PR branch.
           #
@@ -195,7 +197,7 @@ jobs:
 
           # Save version-bump files from the release PR branch (release-please output)
           STASH_DIR=$(mktemp -d)
-          for f in CHANGELOG.md composer.json src/Version.php .release-please-manifest.json; do
+          for f in CHANGELOG.md src/Version.php .release-please-manifest.json; do
             if [ -f "$f" ]; then
               mkdir -p "$STASH_DIR/$(dirname "$f")"
               cp "$f" "$STASH_DIR/$f"
@@ -211,7 +213,7 @@ jobs:
           git clean -fdx
 
           # Restore version-bump files from the release PR branch
-          for f in CHANGELOG.md composer.json src/Version.php .release-please-manifest.json; do
+          for f in CHANGELOG.md src/Version.php .release-please-manifest.json; do
             if [ -f "$STASH_DIR/$f" ]; then
               mkdir -p "$(dirname "$f")"
               cp "$STASH_DIR/$f" "$f"
@@ -219,6 +221,14 @@ jobs:
             fi
           done
           rm -rf "$STASH_DIR"
+
+          # Runtime dependencies belong to the generated next tree. Fail closed
+          # if release reconciliation ever changes either Composer file.
+          if ! git diff --quiet origin/next -- composer.json composer.lock; then
+            echo "::error::Release synchronization changed generated Composer state"
+            git diff -- origin/next -- composer.json composer.lock
+            exit 1
+          fi
 
           # Commit if there are changes
           if git diff --cached --quiet; then


### PR DESCRIPTION
## Why
Release PR #382 restored production `composer.json` over the generated `next` tree while retaining `next`'s `composer.lock`. That reintroduced `standard-webhooks/standard-webhooks` only in the manifest and made Composer fail closed because the lockfile did not contain it. The generated webhook verifier uses native sodium and `next` correctly omits this dependency.

## Change
- classify `composer.json` and `composer.lock` as generated SDK state, not release metadata
- preserve only CHANGELOG/version/manifest release files during synthetic scanning and tree reconciliation
- fail closed if either Composer file differs from `next` after reconciliation
- remove `composer.json` from the release auto-merge allowlist
- add a static regression contract

## Validation
- RED: the new preservation contract failed against the prior workflow
- `python3 .github/scripts/test_release_pr_ci_gate.py -v`
- `python3 .github/scripts/test_release_pr_auto_merge.py -v`
- Python compilation
- `git diff --check`
- actionlint reports only the pre-existing SC2034 warning at unchanged line 261

After merge, rerunning Release Please from `next` must regenerate #382 with matching generated Composer files and pass bootstrap.